### PR TITLE
Update vw_spectra.py

### DIFF
--- a/vw_spectra.py
+++ b/vw_spectra.py
@@ -111,7 +111,7 @@ class VWSpectra(ss.Spectra):
             nlines = len(self.lines[(elem,ion)])
             tau = np.zeros([nlines, self.NumLos,self.nbins])
             for ll in range(nlines):
-                line = list(self.lines[(elem,ion)].values())[ll]
+                line = list(self.lines[(elem,ion)].keys())[ll]
                 tau_loc = self.compute_spectra(elem, ion, line, True)
                 tau[ll,:,:] = tau_loc
                 del tau_loc


### PR DESCRIPTION
I think [Here](https://github.com/sbird/fake_spectra/blob/acef42bb977cb58a2d1594ea988f07019932b935/fake_spectra/spectra.py#L450), in fake_secptra, since self.lines is a dictionary, we should pass the keys() to this function, instead of values(). Do you agree ?

It fixes the error below which I used to get:
```
~/.local/lib/python3.7/site-packages/fake_spectra/spectra.py in _interpolate_single_file(self, nsegment, elem, ion, ll, get_tau, load_all_data_first)
    448                     break
    449             else:
--> 450                 line = self.lines[(elem,ion)][ll]
    451         else:
    452             #If get_tau is false, we don't use the line data

KeyError: <fake_spectra.line_data.Line object at 0x7efbeb549c50>
```

After fixing this, the code is running without error and seems it is regenerating the spectra. I can say the result tomorrow morning probably, after the run finishes. (The workers in Pierce are kicking me outside the building now :) )